### PR TITLE
Fix Home Assistant 2024.6.4 and newer compatibility

### DIFF
--- a/custom_components/nadtcp2/media_player.py
+++ b/custom_components/nadtcp2/media_player.py
@@ -474,7 +474,7 @@ class NADEntity(MediaPlayerEntity):
             if CMD_SOURCE in state:
                 self._source = state[CMD_SOURCE]
 
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         async def disconnect(event):
             await self._client.disconnect()


### PR DESCRIPTION
The current version throws error "custom integration 'nadtcp2' calls async_write_ha_state from a thread other than the event loop, which may cause Home Assistant to crash or data to corrupt". This fixes the integration on more recent HA versions.